### PR TITLE
fix(event-aggregator): removing another callback when called twice

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,10 @@ export class EventAggregator {
       subscribers.push(callback);
 
       return function(){
-        subscribers.splice(subscribers.indexOf(callback), 1);
+        var idx = subscribers.indexOf(callback);
+        if (idx != -1) {
+          subscribers.splice(idx, 1);
+        }
       };
     }else{
       handler = new Handler(event, callback);
@@ -58,7 +61,10 @@ export class EventAggregator {
       subscribers.push(handler);
 
       return function(){
-        subscribers.splice(subscribers.indexOf(handler), 1);
+        var idx = subscribers.indexOf(handler);
+        if (idx != -1) {
+          subscribers.splice(idx, 1);
+        }
       };
     }
   }

--- a/test/event-aggregator.spec.js
+++ b/test/event-aggregator.spec.js
@@ -6,6 +6,22 @@ describe('event aggregator', () =>{
 
     describe('string events', () =>{
 
+      it('should not remove another callback when execute called twice', ()=>{
+        var ea = new EventAggregator();
+
+        var data = 0;
+
+        var executeMe = ea.subscribe('dinner', function() {});
+        ea.subscribe('dinner', function() { data = 1; });
+
+        executeMe();
+        executeMe();
+
+        ea.publish('dinner');
+
+        expect(data).toBe(1);
+      });
+
       it('adds event with callback to the eventLookup object', () =>{
         var ea = new EventAggregator();
 
@@ -87,6 +103,22 @@ describe('event aggregator', () =>{
 
     describe('handler events', () =>{
 
+      it('should not remove another handler when execute called twice', ()=>{
+        var ea = new EventAggregator();
+
+        var data = 0;
+
+        var executeMe = ea.subscribe(DinnerEvent, function() {});
+        ea.subscribe(AnotherDinnerEvent, function() { data = 1; });
+
+        executeMe();
+        executeMe();
+
+        ea.publish(new AnotherDinnerEvent(""));
+
+        expect(data).toBe(1);
+      });
+
       it('adds handler with messageType and callback to the messageHandlers array', ()=>{
         var ea = new EventAggregator();
 
@@ -117,7 +149,7 @@ describe('event aggregator', () =>{
 
     describe('string events', () =>{
 
-      it('adds event with an anynomous function that will execute the callback to the eventLookup object', () =>{
+      it('adds event with an anynomous function that will execute the callback to the eventLookup object', ()=>{
         var ea = new EventAggregator();
 
         var callback = function(){};
@@ -328,6 +360,16 @@ describe('event aggregator', () =>{
 });
 
 class DinnerEvent {
+  constructor(message){
+    this._message = message;
+  }
+
+  get message(){
+    return this._message;
+  }
+}
+
+class AnotherDinnerEvent {
   constructor(message){
     this._message = message;
   }


### PR DESCRIPTION
when calling the destroy function twice, indexOf returns -1 and splice
will remove the last element.

I ran into this on accident when subscribing to an event in a constructor and unsubscribing in deactivate().
