### PR TITLE
fix(publish): catch errors thrown in subscribers

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This library is part of the [Aurelia](http://www.aurelia.io/) platform and conta
 
 ## Dependencies
 
-This library has **NO** external dependencies.
+* [aurelia-logging](https://github.com/aurelia/logging)
 
 ## Used By
 

--- a/config.js
+++ b/config.js
@@ -1,6 +1,13 @@
 System.config({
   "paths": {
-    "*": "*.js"
+    "*": "*.js",
+    "github:*": "jspm_packages/github/*.js"
+  }
+});
+
+System.config({
+  "map": {
+    "aurelia-logging": "github:aurelia/logging@0.4.0"
   }
 });
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "format": "register",
     "directories": {
       "lib": "dist/system"
+    },
+    "dependencies": {
+      "aurelia-logging": "github:aurelia/logging@^0.4.0"
     }
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,7 @@
+import * as LogManager from 'aurelia-logging';
+
+const logger = LogManager.getLogger('event-aggregator');
+
 class Handler {
   constructor(messageType, callback){
     this.messageType = messageType;
@@ -6,8 +10,16 @@ class Handler {
 
   handle(message){
     if(message instanceof this.messageType){
-      this.callback.call(null, message);
+      executeHandler(() => this.callback.call(null, message));
     }
+  }
+}
+
+function executeHandler(handler) {
+  try {
+    handler();
+  } catch(e) {
+    logger.error(e);
   }
 }
 
@@ -27,7 +39,7 @@ export class EventAggregator {
         i = subscribers.length;
 
         while(i--) {
-          subscribers[i](data, event);
+          executeHandler(() => subscribers[i](data, event));
         }
       }
     }else{

--- a/test/event-aggregator.spec.js
+++ b/test/event-aggregator.spec.js
@@ -313,6 +313,29 @@ describe('event aggregator', () =>{
         expect(someData).toBeUndefined();
       });
 
+      it('handles errors in subscriber callbacks', () => {
+        var ea = new EventAggregator();
+
+        var someMessage;
+
+        var crash = function() {
+          throw new Error('oops');
+        }
+
+        var callback = function(message){
+          someMessage = message;
+        };
+
+        var data = {foo: 'bar'};
+
+        ea.subscribe('dinner', crash);
+        ea.subscribe('dinner', callback);
+
+        ea.publish('dinner', data);
+
+        expect(someMessage).toBe(data);
+      });
+
     });
 
     describe('handler events', () =>{
@@ -351,6 +374,30 @@ describe('event aggregator', () =>{
         ea.publish(new DrinkingEvent());
 
         expect(someMessage).toBeUndefined();
+      });
+
+
+      it('handles errors in subscriber callbacks', () => {
+        var ea = new EventAggregator();
+
+        var someMessage;
+
+        var crash = function() {
+          throw new Error('oops');
+        }
+
+        var callback = function(message){
+          someMessage = message;
+        };
+
+        var data = {foo: 'bar'};
+
+        ea.subscribe(DinnerEvent, crash);
+        ea.subscribe(DinnerEvent, callback);
+
+        ea.publish(new DinnerEvent(data));
+
+        expect(someMessage.message).toBe(data);
       });
 
     });


### PR DESCRIPTION
Subscribers are executed synchronously, so errors thrown by subscribers can break the publisher. This can leave code like the router in an invalid state. This change causes the `publish` method to log subscriber errors to the console and continue execution.